### PR TITLE
package.json: update repo url to recent rename

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "react native svg library",
     "repository": {
         "type": "git",
-        "url": "https://github.com/magicismight/react-native-art-svg"
+        "url": "https://github.com/magicismight/react-native-svg"
     },
     "license": "MIT",
     "main": "./index.js",


### PR DESCRIPTION
Should close #18 since that the only reference left (except the one in the README that mention the change of the name).