### PR TITLE
Fix createReactNativeComponentClass import for RN 0.26.0

### DIFF
--- a/elements/G.js
+++ b/elements/G.js
@@ -1,5 +1,5 @@
 import React, {Component, PropTypes} from 'react';
-import createReactNativeComponentClass from 'react-native/Libraries/ReactNative/createReactNativeComponentClass';
+import createReactNativeComponentClass from 'react/lib/createReactNativeComponentClass';
 import Defs from './Defs';
 import _ from 'lodash';
 import {GroupAttributes} from '../lib/attributes';

--- a/elements/Image.js
+++ b/elements/Image.js
@@ -3,7 +3,7 @@ import extractProps from '../lib/extract/extractProps';
 import {ImageAttributes} from '../lib/attributes';
 import {numberProp} from '../lib/props';
 import resolveAssetSource from 'react-native/Libraries/Image/resolveAssetSource';
-import createReactNativeComponentClass from 'react-native/Libraries/ReactNative/createReactNativeComponentClass';
+import createReactNativeComponentClass from 'react/lib/createReactNativeComponentClass';
 import formatPercentageProps from '../lib/formatPercentageProps';
 
 class Image extends Component{

--- a/elements/Path.js
+++ b/elements/Path.js
@@ -1,7 +1,7 @@
 import React, {Component, PropTypes} from 'react';
 import _ from 'lodash';
 import Defs from './Defs';
-import createReactNativeComponentClass from 'react-native/Libraries/ReactNative/createReactNativeComponentClass';
+import createReactNativeComponentClass from 'react/lib/createReactNativeComponentClass';
 import extractProps from '../lib/extract/extractProps';
 import SerializablePath from '../lib/SerializablePath';
 import {PathAttributes} from '../lib/attributes';

--- a/elements/Shape.js
+++ b/elements/Shape.js
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import extractProps from '../lib/extract/extractProps';
 import {ShapeAttributes} from '../lib/attributes';
 import formatPercentageProps from '../lib/formatPercentageProps';
-import createReactNativeComponentClass from 'react-native/Libraries/ReactNative/createReactNativeComponentClass';
+import createReactNativeComponentClass from 'react/lib/createReactNativeComponentClass';
 import {circleProps, ellipseProps, lineProps, rectProps} from '../lib/props';
 
 /**

--- a/elements/Text.js
+++ b/elements/Text.js
@@ -1,7 +1,7 @@
 import React, {Component, PropTypes} from 'react';
 import Defs from './Defs';
 import _ from 'lodash';
-import createReactNativeComponentClass from 'react-native/Libraries/ReactNative/createReactNativeComponentClass';
+import createReactNativeComponentClass from 'react/lib/createReactNativeComponentClass';
 import extractProps from '../lib/extract/extractProps';
 import extractText from '../lib/extract/extractText';
 import {TextAttributes} from '../lib/attributes';


### PR DESCRIPTION
This broke again in React Native 0.26.0.

`createReactNativeComponentClass` is no longer under `react-native/Libraries/ReactNative/`, it's under `react/lib/`.