### PR TITLE
SVG images double rendering on Android

### DIFF
--- a/android/src/main/java/com/horcrux/svg/RNSVGImageShadowNode.java
+++ b/android/src/main/java/com/horcrux/svg/RNSVGImageShadowNode.java
@@ -92,34 +92,33 @@ public class RNSVGImageShadowNode extends RNSVGPathShadowNode {
         if (inMemoryCache) {
             tryRender(request, canvas, paint, opacity);
         } else if (!mLoading) {
-            loadImage(request, canvas, paint);
+            loadBitmap(request, canvas, paint);
         }
     }
 
-    private void loadImage(@Nonnull final ImageRequest request, @Nonnull final Canvas canvas, @Nonnull final Paint paint) {
+    private void loadBitmap(@Nonnull final ImageRequest request, @Nonnull final Canvas canvas, @Nonnull final Paint paint) {
         final DataSource<CloseableReference<CloseableImage>> dataSource
                 = Fresco.getImagePipeline().fetchDecodedImage(request, getThemedContext());
 
-        dataSource.subscribe(
-                new BaseBitmapDataSubscriber() {
-                    @Override
-                    public void onNewResultImpl(@Nullable Bitmap bitmap) {
-                        if (bitmap != null) {
-                            canvas.drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR);
-                            paint.reset();
-                            getSvgShadowNode().drawChildren(canvas, paint);
-                            mLoading = false;
-                        }
-                    }
+        dataSource.subscribe(new BaseBitmapDataSubscriber() {
+                                 @Override
+                                 public void onNewResultImpl(@Nullable Bitmap bitmap) {
+                                     if (bitmap != null) {
+                                         canvas.drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR);
+                                         paint.reset();
+                                         getSvgShadowNode().drawChildren(canvas, paint);
+                                         mLoading = false;
+                                     }
+                                 }
 
-                    @Override
-                    public void onFailureImpl(DataSource dataSource) {
-                        // No cleanup required here.
-                        // TODO: more details about this failure
-                        mLoading = false;
-                        FLog.w(ReactConstants.TAG, dataSource.getFailureCause(), "RNSVG: fetchDecodedImage failed!");
-                    }
-                },
+                                 @Override
+                                 public void onFailureImpl(DataSource dataSource) {
+                                     // No cleanup required here.
+                                     // TODO: more details about this failure
+                                     mLoading = false;
+                                     FLog.w(ReactConstants.TAG, dataSource.getFailureCause(), "RNSVG: fetchDecodedImage failed!");
+                                 }
+                             },
                 UiThreadImmediateExecutorService.getInstance()
         );
     }

--- a/android/src/main/java/com/horcrux/svg/RNSVGSvgViewShadowNode.java
+++ b/android/src/main/java/com/horcrux/svg/RNSVGSvgViewShadowNode.java
@@ -18,6 +18,7 @@ import android.graphics.Point;
 import android.util.Log;
 import android.view.ViewGroup;
 
+import com.facebook.imagepipeline.request.ImageRequest;
 import com.facebook.react.uimanager.LayoutShadowNode;
 import com.facebook.react.uimanager.UIViewOperationQueue;
 
@@ -52,7 +53,17 @@ public class RNSVGSvgViewShadowNode extends LayoutShadowNode {
         return bitmap;
     }
 
-    public void drawChildren(Canvas canvas, Paint paint) {
+    /**
+     * Draw all of the child nodes of this root node
+     *
+     * This method is synchronized since
+     * {@link com.horcrux.svg.RNSVGImageShadowNode#loadImage(ImageRequest, Canvas, Paint)} calls it
+     * asynchronously after images have loaded and are ready to be drawn.
+     *
+     * @param canvas
+     * @param paint
+     */
+    public synchronized void drawChildren(Canvas canvas, Paint paint) {
         for (int i = 0; i < getChildCount(); i++) {
             RNSVGVirtualNode child = (RNSVGVirtualNode) getChildAt(i);
             child.setupDimensions(canvas);

--- a/android/src/main/java/com/horcrux/svg/RNSVGVirtualNode.java
+++ b/android/src/main/java/com/horcrux/svg/RNSVGVirtualNode.java
@@ -69,7 +69,7 @@ public abstract class RNSVGVirtualNode extends LayoutShadowNode {
     private RNSVGSvgViewShadowNode mSvgShadowNode;
 
     public RNSVGVirtualNode() {
-        mScale = DisplayMetricsHolder.getWindowDisplayMetrics().density;
+        mScale = DisplayMetricsHolder.getScreenDisplayMetrics().density;
     }
 
     public abstract void draw(Canvas canvas, Paint paint, float opacity);


### PR DESCRIPTION
Fixing RNSVGImageShadowNode to no longer dangerously store a reference
to a DataSource result, since it's only valid for the lifetime of the
onNewResultImpl() method. Instead, the images are rendered from the
Fresco image bitmap cache.

Updating RNSVGVirtualNode to call getScreenDisplayMetrics() instead of
getWindowDisplayMetrics(), since the latter is deprecated.

Synchronizing access to RNSVGSvgViewShadowNode.drawChildren(), since
it can be called by multiple threads simultaneously (the native UI
thread and the asynchronous Image loader callback).