### PR TITLE
Android: SVG Images not rendering the first time a view is displayed

### DIFF
--- a/android/src/main/java/com/horcrux/svg/RNSVGPathShadowNode.java
+++ b/android/src/main/java/com/horcrux/svg/RNSVGPathShadowNode.java
@@ -310,7 +310,9 @@ public class RNSVGPathShadowNode extends RNSVGVirtualNode {
                 mPath.computeBounds(box, true);
             }
             PropHelper.RNSVGBrush brush = getSvgShadowNode().getDefinedBrush(colors.getString(1));
-            brush.setupPaint(paint, box, mScale, opacity);
+            if (brush != null) {
+                brush.setupPaint(paint, box, mScale, opacity);
+            }
         } else {
             // TODO: Support pattern.
             FLog.w(ReactConstants.TAG, "RNSVG: Color type " + colorType + " not supported!");

--- a/android/src/main/java/com/horcrux/svg/RNSVGSvgViewManager.java
+++ b/android/src/main/java/com/horcrux/svg/RNSVGSvgViewManager.java
@@ -10,12 +10,13 @@
 package com.horcrux.svg;
 
 import android.graphics.Bitmap;
-import android.util.Log;
 
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
 
 import java.util.ArrayList;
+
+import javax.annotation.Nullable;
 
 /**
  * ViewManager for RNSVGSvgView React views. Renders as a {@link RNSVGSvgView} and handles
@@ -24,6 +25,7 @@ import java.util.ArrayList;
 public class RNSVGSvgViewManager extends ViewGroupManager<RNSVGSvgView> {
 
     private static final String REACT_CLASS = "RNSVGSvgView";
+    private RNSVGSvgView svgView = null;
 
     // TODO: use an ArrayList to connect RNSVGSvgViewShadowNode with RNSVGSvgView, not sure if there will be a race condition.
     // TODO: find a better way to replace this
@@ -34,9 +36,14 @@ public class RNSVGSvgViewManager extends ViewGroupManager<RNSVGSvgView> {
         return REACT_CLASS;
     }
 
+    @Nullable
+    public RNSVGSvgView getSvgView() {
+        return this.svgView;
+    }
+
     @Override
     public RNSVGSvgViewShadowNode createShadowNodeInstance() {
-        RNSVGSvgViewShadowNode node = new RNSVGSvgViewShadowNode();
+        RNSVGSvgViewShadowNode node = new RNSVGSvgViewShadowNode(this);
         SvgShadowNodes.add(node);
         return node;
     }
@@ -50,7 +57,8 @@ public class RNSVGSvgViewManager extends ViewGroupManager<RNSVGSvgView> {
     protected RNSVGSvgView createViewInstance(ThemedReactContext reactContext) {
         RNSVGSvgViewShadowNode shadowNode = SvgShadowNodes.get(0);
         SvgShadowNodes.remove(0);
-        return new RNSVGSvgView(reactContext, shadowNode);
+        this.svgView = new RNSVGSvgView(reactContext, shadowNode);
+        return this.svgView;
     }
 
     @Override

--- a/android/src/main/java/com/horcrux/svg/RNSVGSvgViewShadowNode.java
+++ b/android/src/main/java/com/horcrux/svg/RNSVGSvgViewShadowNode.java
@@ -13,14 +13,18 @@ import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.Point;
-import android.util.Log;
+import android.graphics.Rect;
+import android.view.View;
 import android.view.ViewGroup;
 
+import com.facebook.imagepipeline.request.ImageRequest;
 import com.facebook.react.uimanager.LayoutShadowNode;
 import com.facebook.react.uimanager.UIViewOperationQueue;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import javax.annotation.Nonnull;
 
 /**
  * Shadow node for RNSVG virtual tree root - RNSVGSvgView
@@ -31,6 +35,13 @@ public class RNSVGSvgViewShadowNode extends LayoutShadowNode {
     private static final Map<String, RNSVGVirtualNode> mDefinedClipPaths = new HashMap<>();
     private static final Map<String, RNSVGVirtualNode> mDefinedTemplates = new HashMap<>();
     private static final Map<String, PropHelper.RNSVGBrush> mDefinedBrushes = new HashMap<>();
+
+    @Nonnull private final RNSVGSvgViewManager viewManager;
+
+    public RNSVGSvgViewShadowNode(@Nonnull final RNSVGSvgViewManager viewManager) {
+        super();
+        this.viewManager = viewManager;
+    }
 
     @Override
     public void onCollectExtraUpdates(UIViewOperationQueue uiUpdater) {
@@ -54,7 +65,7 @@ public class RNSVGSvgViewShadowNode extends LayoutShadowNode {
      * Draw all of the child nodes of this root node
      *
      * This method is synchronized since
-     * {@link com.horcrux.svg.RNSVGImageShadowNode#loadImage(ImageRequest, Canvas, Paint)} calls it
+     * {@link com.horcrux.svg.RNSVGImageShadowNode#loadBitmap(ImageRequest, Canvas, Paint)} calls it
      * asynchronously after images have loaded and are ready to be drawn.
      *
      * @param canvas
@@ -73,6 +84,16 @@ public class RNSVGSvgViewShadowNode extends LayoutShadowNode {
 
             if (child.isResponsible() && !mResponsible) {
                 mResponsible = true;
+            }
+        }
+    }
+
+    protected void invalidateView(@Nonnull final Rect dirtyRect) {
+        final RNSVGSvgView svgView = this.viewManager.getSvgView();
+        if (svgView != null) {
+            final View rootView = svgView.getRootView();
+            if (rootView != null) {
+                rootView.invalidate(dirtyRect);
             }
         }
     }

--- a/android/src/main/java/com/horcrux/svg/RNSVGVirtualNode.java
+++ b/android/src/main/java/com/horcrux/svg/RNSVGVirtualNode.java
@@ -9,8 +9,6 @@
 
 package com.horcrux.svg;
 
-import javax.annotation.Nullable;
-
 import android.graphics.Canvas;
 import android.graphics.Matrix;
 import android.graphics.Paint;
@@ -18,16 +16,16 @@ import android.graphics.Path;
 import android.graphics.Point;
 import android.graphics.Rect;
 import android.graphics.Region;
-import android.util.Log;
 import android.view.View;
 
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.uimanager.DisplayMetricsHolder;
 import com.facebook.react.uimanager.LayoutShadowNode;
-import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.ReactShadowNode;
+import com.facebook.react.uimanager.annotations.ReactProp;
 
+import javax.annotation.Nullable;
 
 /**
  * Base class for RNSVGView virtual nodes: {@link RNSVGGroupShadowNode}, {@link RNSVGPathShadowNode} and
@@ -81,8 +79,7 @@ public abstract class RNSVGVirtualNode extends LayoutShadowNode {
      * @param canvas the canvas to set up
      */
     protected final int saveAndSetupCanvas(Canvas canvas) {
-        int count = canvas.getSaveCount();
-        canvas.save();
+        final int count = canvas.save();
         if (mMatrix != null) {
             canvas.concat(mMatrix);
         }


### PR DESCRIPTION
Since SVG images are loaded asynchronously, we need to invalidate the
view after drawing to the canvas so that the view will be re-rendered.

Storing a reference to the actual SvgView in ViewManager, and passing a
reference to the ViewManager to each shadow node, so that shadow nodes
can invalidate the root SVG view.

(Also fixing a NPE caused by getDefinedBrush() returning null).