### PR TITLE
fixes #95 - crash whenever <Defs> are used on iOS

### DIFF
--- a/ios/RNSVGNode.m
+++ b/ios/RNSVGNode.m
@@ -188,6 +188,11 @@
     // abstract
 }
 
+- (void)mergeProperties:(__kindof RNSVGNode *)target mergeList:(NSArray<NSString *> *)mergeList inherited:(BOOL)inherited
+{
+    // abstract
+}
+
 - (void)resetProperties
 {
     // abstract


### PR DESCRIPTION
This fixes the crash dsecribed by #95 and causes my graphic to render correctly (the clip-path inside my defs is respected). This is the first iOS code I've ever written (well, copy-pasted :)) so its possible I've done something silly, but hey ... it works!