### PR TITLE
translate then scale - fixes #98

### DIFF
--- a/android/src/main/java/com/horcrux/svg/RNSVGViewBoxShadowNode.java
+++ b/android/src/main/java/com/horcrux/svg/RNSVGViewBoxShadowNode.java
@@ -159,8 +159,11 @@ public class RNSVGViewBoxShadowNode extends RNSVGGroupShadowNode {
 
         }
 
-        mMatrix.postScale(scaleX, scaleY);
+        // The transform applied to content contained by the element is given by
+        // translate(translate-x, translate-y) scale(scale-x, scale-y).
         mMatrix.postTranslate(-translateX * (mFromSymbol ? scaleX : 1), -translateY * (mFromSymbol ? scaleY : 1));
+        mMatrix.postScale(scaleX, scaleY);
+        
         super.draw(canvas, paint, opacity);
     }
 


### PR DESCRIPTION
Lucky for me you left a comment in the code pointing to [the draft spec algorithm](https://svgwg.org/svg2-draft/coords.html#ComputingAViewportsTransform). I noticed the following mismatch between the spec and the Android implementation:

Spec:
> The transform applied to content contained by the element is given by translate(translate-x, translate-y) scale(scale-x, scale-y).

Implementation:
```
mMatrix.postScale(scaleX, scaleY);
mMatrix.postTranslate(-translateX * (mFromSymbol ? scaleX : 1), -translateY * (mFromSymbol ? scaleY : 1));
```

Switching the order to match the spec (translate then scale) resolves #98 