### PR TITLE
fixes #96 for Android only - viewBox or nested G elements stifle events

### DIFF
--- a/android/src/main/java/com/horcrux/svg/RNSVGGroupShadowNode.java
+++ b/android/src/main/java/com/horcrux/svg/RNSVGGroupShadowNode.java
@@ -91,9 +91,10 @@ public class RNSVGGroupShadowNode extends RNSVGPathShadowNode {
 
             RNSVGVirtualNode node = (RNSVGVirtualNode) child;
 
-            viewTag = node.hitTest(point, ((ViewGroup) view).getChildAt(i), combinedMatrix);
+            View childView = ((ViewGroup) view).getChildAt(i);
+            viewTag = node.hitTest(point, childView, combinedMatrix);
             if (viewTag != -1) {
-                return node.isResponsible() ? viewTag : view.getId();
+                return (node.isResponsible() || (viewTag != childView.getId())) ? viewTag : view.getId();
             }
         }
 


### PR DESCRIPTION
This appears to fix #96 on Android ... I'm not much use with iOS although I'm prepared to have a look at it maybe tomorrow. I suspect the same logic problem is tripping up the iOS version too ...