### PR TITLE
Fixes #104 - re-draws on Android apply viewbox transforms repeatedly

### DIFF
--- a/android/src/main/java/com/horcrux/svg/RNSVGViewBoxShadowNode.java
+++ b/android/src/main/java/com/horcrux/svg/RNSVGViewBoxShadowNode.java
@@ -159,6 +159,7 @@ public class RNSVGViewBoxShadowNode extends RNSVGGroupShadowNode {
 
         }
 
+        mMatrix.reset();
         mMatrix.postScale(scaleX, scaleY);
         mMatrix.postTranslate(-translateX * (mFromSymbol ? scaleX : 1), -translateY * (mFromSymbol ? scaleY : 1));
         super.draw(canvas, paint, opacity);


### PR DESCRIPTION
fixes #104 by resetting the matrix at each draw to prevent applying the transforms on top of the previous transforms